### PR TITLE
Add the ability to reset container values

### DIFF
--- a/src/Pimple/Container.php
+++ b/src/Pimple/Container.php
@@ -145,6 +145,31 @@ class Container implements \ArrayAccess
             unset($this->values[$id], $this->frozen[$id], $this->raw[$id], $this->keys[$id]);
         }
     }
+    
+    /**
+     * Resets a parameter or an object.
+     *
+     * The value will be recreated on the next access.
+     *
+     * @param string $id The unique identifier for the parameter or object
+     *
+     * @throws \InvalidArgumentException if the identifier is not defined
+     */
+    public function offsetReset($id)
+    {
+        if (!isset($this->keys[$id])) {
+            throw new \InvalidArgumentException(sprintf('Identifier "%s" is not defined.', $id));
+        }
+
+        if (isset($this->raw[$id])) {
+            $this->values[$id] = $this->raw[$id];
+            unset($this->raw[$id]);
+        }
+
+        if (isset($this->frozen[$id])) {
+            unset($this->frozen[$id]);
+        }
+    }
 
     /**
      * Marks a callable as being a factory service.


### PR DESCRIPTION
Hello,
It would be really nice to be able to reset a container value after it's been accessed.  The main use case for this is in resetting Doctrine ObjectManagers once they've been closed.

As discussed in silexphp/Pimple#72